### PR TITLE
remove the default annotations and provide a sample values.yaml for use with nginx ingress

### DIFF
--- a/ibm-fhir-server/README.md
+++ b/ibm-fhir-server/README.md
@@ -61,7 +61,13 @@ To connect to your database from outside the cluster execute the following comma
 | audit.geoCity | string | `nil` | The city where the server is running |
 | audit.geoCountry | string | `nil` | The country where the server is running |
 | audit.geoState | string | `nil` | The state where the server is running |
-| audit.kafka | object | `{"bootstrapServers":null,"saslJaasConfig":null,"saslMechanism":"PLAIN","securityProtocol":"SASL_SSL","sslEnabledProtocols":"TLSv1.2","sslEndpointIdentificationAlgorithm":"HTTPS","sslProtocol":"TLSv1.2"}` | Kafka connection properties |
+| audit.kafka.bootstrapServers | string | `nil` |  |
+| audit.kafka.saslJaasConfig | string | `nil` |  |
+| audit.kafka.saslMechanism | string | `"PLAIN"` |  |
+| audit.kafka.securityProtocol | string | `"SASL_SSL"` |  |
+| audit.kafka.sslEnabledProtocols | string | `"TLSv1.2"` |  |
+| audit.kafka.sslEndpointIdentificationAlgorithm | string | `"HTTPS"` |  |
+| audit.kafka.sslProtocol | string | `"TLSv1.2"` |  |
 | audit.kafkaApiKey | string | `nil` |  |
 | audit.kafkaServers | string | `nil` |  |
 | audit.topic | string | `"FHIR_AUDIT_DEV"` | The target Kafka topic for audit events |
@@ -82,13 +88,7 @@ To connect to your database from outside the cluster execute the following comma
 | image.repository | string | `"ibmcom/ibm-fhir-server"` |  |
 | image.tag | string | `"4.8.3"` |  |
 | ingestionReplicas | int | `2` | The number of replicas for the internal-access FHIR server pods |
-| ingress.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"HTTPS"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/configuration-snippet" | string | `"proxy_set_header X-FHIR-FORWARDED-URL \"https://$host$request_uri\";\n"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/proxy-ssl-name" | string | `"{{- range $host := $.Values.ingress.hosts }} {{ $host }}; {{ end }}\n"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/proxy-ssl-protocols" | string | `"TLSv1.2 TLSv1.3"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/proxy-ssl-verify" | string | `"true"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/server-snippet" | string | `"add_header Strict-Transport-Security \"max-age=86400; includeSubDomains\";\n"` |  |
-| ingress.annotations."nginx.ingress.kubernetes.io/use-regex" | string | `"true"` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
 | ingress.hostname | string | `"fhir.example.com"` | The default cluster hostname, used for both ingress.rules.host and ingress.tls.hosts. If you have more than one, you'll need to set overrides for the rules and tls separately. |
 | ingress.rules[0].host | string | `"{{ .Release.Name }}.{{ $.Values.ingress.hostname }}"` |  |

--- a/ibm-fhir-server/templates/NOTES.txt
+++ b/ibm-fhir-server/templates/NOTES.txt
@@ -10,14 +10,14 @@ To learn more about the release, try:
 {{ if .Values.ingress.enabled -}}
 To use the release, try the following URLs:
 {{- range .Values.ingress.rules }}
-* https:{{ .host }}/fhir-server/api/v4/metadata
-* https:{{ .host }}/openapi/ui
+* https://{{ tpl .host $ }}/fhir-server/api/v4/metadata
+* https://{{ tpl .host $ }}/openapi/ui
 {{- end }}
 
 Or check the health of the server via curl:
 {{- range .Values.ingress.rules }}
 ```
-curl -i -u 'fhiruser:<YOUR_FHIR_USER_PASSWORD>' 'https:{{ .host }}/fhir-server/api/v4/$healthcheck'
+curl -i -u 'fhiruser:<YOUR_FHIR_USER_PASSWORD>' 'https://{{ tpl .host $ }}/fhir-server/api/v4/$healthcheck'
 ```
 {{- end }}
 {{ end }}

--- a/ibm-fhir-server/values-nginx.yaml
+++ b/ibm-fhir-server/values-nginx.yaml
@@ -1,0 +1,9 @@
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: >-
+      add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
+    nginx.ingress.kubernetes.io/configuration-snippet: >-
+      proxy_set_header X-FHIR-FORWARDED-URL "https://$host$request_uri";
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/proxy-ssl-protocols: TLSv1.2 TLSv1.3
+    nginx.ingress.kubernetes.io/proxy-ssl-verify: "true"

--- a/ibm-fhir-server/values.yaml
+++ b/ibm-fhir-server/values.yaml
@@ -38,7 +38,6 @@ audit:
   enabled: false
   kafkaServers:
   kafkaApiKey:
-  # -- Kafka connection properties
   kafka:
     bootstrapServers:
     saslMechanism: PLAIN
@@ -68,17 +67,7 @@ objectStorage:
   batchIdEncryptionKey:
 ingress:
   enabled: true
-  annotations:
-    nginx.ingress.kubernetes.io/server-snippet: >
-      add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
-    nginx.ingress.kubernetes.io/configuration-snippet: >
-      proxy_set_header X-FHIR-FORWARDED-URL "https://$host$request_uri";
-    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/proxy-ssl-name: >
-      {{- range $host := $.Values.ingress.hosts }} {{ $host }}; {{ end }}
-    nginx.ingress.kubernetes.io/proxy-ssl-protocols: TLSv1.2 TLSv1.3
-    nginx.ingress.kubernetes.io/proxy-ssl-verify: "true"
+  annotations: {}
   # -- The default cluster hostname, used for both ingress.rules.host and ingress.tls.hosts.
   # If you have more than one, you'll need to set overrides for the rules and tls separately.
   hostname: fhir.example.com


### PR DESCRIPTION
This cleans up the README quite a bit.  For review purposes, just compare
https://github.com/Alvearie/alvearie-helm/blob/lee-main/ibm-fhir-server/README.md#values to 
https://github.com/Alvearie/alvearie-helm/blob/main/ibm-fhir-server/README.md#values