### PR TITLE
fix the healthcheck endpoint in the readiness probe

### DIFF
--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.1.2
+version: 0.1.3
 appVersion: 4.9.1
 sources:
   - https://github.com/Alvearie/alvearie-helm

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 The [IBM FHIR Server](https://ibm.github.io/FHIR) implements version 4 of the HL7 FHIR specification

--- a/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
+++ b/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
@@ -7,12 +7,10 @@ The default fhir-server-config.json.
         "__comment": "FHIR Server configuration",
         "fhirServer": {
             "core": {
-                "tenantIdHeaderName": "X-FHIR-TENANT-ID",
-                "datastoreIdHeaderName": "X-FHIR-DSID",
-                "originalRequestUriHeaderName": "X-FHIR-FORWARDED-URL",
-                "checkReferenceTypes": true,
-                "conditionalDeleteMaxNumber": 10,
                 "serverRegistryResourceProviderEnabled": {{ .Values.serverRegistryResourceProviderEnabled }},
+                {{- if .Values.ingress.enabled }}
+                "externalBaseUrl": "https://{{ .Values.ingress.hostname }}/fhir-server/api/v4",
+                {{- end}}
                 "disabledOperations": "",
                 "defaultPrettyPrint": true
             },

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -253,7 +253,7 @@ spec:
               command:
               - bash
               - -c
-              - curl --fail -k -sS -u "fhiruser:${FHIR_USER_PASSWORD}" https://localhost:9443/fhir-server/api/v4/$$healthcheck
+              - curl --fail -k -sS -u "fhiruser:${FHIR_USER_PASSWORD}" 'https://localhost:9443/fhir-server/api/v4/$healthcheck'
             initialDelaySeconds: 40
             periodSeconds: 10
             timeoutSeconds: 2

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
               value: message,trace,accessLog,ffdc,audit
             - name: WLP_LOGGING_JSON_FIELD_MAPPINGS
               value: loglevel:level
+            {{- if .Values.ingress.enabled }}
+            - name: FHIR_HOSTNAME
+              value: "{{ .Values.ingress.hostname }}"
+            {{- end }}
             - name: FHIR_DB_HOSTNAME
               value: "{{ .Values.db.host }}"
             - name: FHIR_DB_PORT

--- a/charts/ibm-fhir-server/templates/service.yaml
+++ b/charts/ibm-fhir-server/templates/service.yaml
@@ -15,6 +15,3 @@ spec:
     - name: https
       protocol: TCP
       port: 9443
-    - name: http
-      protocol: TCP
-      port: 9080


### PR DESCRIPTION
I also added a new env var named `FHIR_HOSTNAME` and set it from ingress.hostname... this way the fhir server can know iits external hostname which is needed for validating the "aud" claims in JWT tokens.  It might also be useful if we want to set `fhirServer/core/externalBaseUrl` instead of relying on users to configure ingress annotations / proxies that add the `X-FHIR-FORWARDED-URL` header.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>