### PR TITLE
issue #32 - control the security section of defaultFhirConfig via helm properties

### DIFF
--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.1.3
+version: 0.1.4
 appVersion: 4.9.1
 sources:
   - https://github.com/Alvearie/alvearie-helm

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 The [IBM FHIR Server](https://ibm.github.io/FHIR) implements version 4 of the HL7 FHIR specification
@@ -272,6 +272,13 @@ If the `objectStorage.objectStorageSecret` value is set, this helm chart will on
 | schemaMigration.image.pullSecret | string | `"all-icr-io"` |  |
 | schemaMigration.image.repository | string | `"ibmcom/ibm-fhir-schematool"` |  |
 | schemaMigration.image.tag | string | `"4.9.1"` |  |
+| security.oauthAuthUrl | string | `nil` |  |
+| security.oauthEnabled | bool | `false` |  |
+| security.oauthRegUrl | string | `nil` |  |
+| security.oauthTokenUrl | string | `nil` |  |
+| security.smartCapabilities | list | sso-openid-connect, launch-standalone, client-public, client-confidential-symmetric, permission-offline, context-standalone-patient, and permission-patient | SMART capabilities to advertise from the server |
+| security.smartEnabled | bool | `false` |  |
+| security.smartScopes | list | openid, profile, fhirUser, launch/patient, offline_access, and a set of patient/<resource>.read scopes for a number of resource types. | OAuth 2.0 scopes to advertise from the server |
 | serverRegistryResourceProviderEnabled | bool | `false` | Indicates whether the server registry resource provider should be used by the FHIR registry component to access definitional resources through the persistence layer |
 
 ----------------------------------------------

--- a/charts/ibm-fhir-server/templates/_extensionSearchParametersJson.tpl
+++ b/charts/ibm-fhir-server/templates/_extensionSearchParametersJson.tpl
@@ -5,10 +5,6 @@ The default extension-search-parameters.json.
 {{- define "defaultSearchParameters" }}
     {
         "resourceType": "Bundle",
-        "id": "searchParams",
-        "meta": {
-            "lastUpdated": "2018-12-27T22:37:54.724+11:00"
-        },
         "type": "collection",
         "entry": []
     }

--- a/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
+++ b/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
@@ -54,6 +54,7 @@ The default fhir-server-config.json.
             },
             "security": {
                 "cors": true,
+                {{- if not .Values.security.oauthEnabled }}
                 "basic": {
                     "enabled": true
                 },
@@ -62,50 +63,22 @@ The default fhir-server-config.json.
                     "authFilter": {
                         "enabled": false
                     }
-                },
+                }
+                {{- else }}
                 "oauth": {
-                    "enabled": false,
-                    "regUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/registration",
-                    "authUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/authorize",
-                    "tokenUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/token",
+                    "enabled": true,
+                    {{- if .Values.oauthRegUrl }}
+                    "regUrl": {{ tpl .Values.security.oauthRegUrl $ | quote }},
+                    {{- end }}
+                    "authUrl": {{ tpl .Values.security.oauthAuthUrl $ | quote }},
+                    "tokenUrl": {{ tpl .Values.security.oauthTokenUrl $ | quote }},
                     "smart": {
-                        "enabled": false,
-                        "scopes": ["openid", "profile", "fhirUser", "launch/patient", "offline_access",
-                            "patient/*.read",
-                            "patient/AllergyIntolerance.read",
-                            "patient/CarePlan.read",
-                            "patient/CareTeam.read",
-                            "patient/Condition.read",
-                            "patient/Device.read",
-                            "patient/DiagnosticReport.read",
-                            "patient/DocumentReference.read",
-                            "patient/Encounter.read",
-                            "patient/ExplanationOfBenefit.read",
-                            "patient/Goal.read",
-                            "patient/Immunization.read",
-                            "patient/Location.read",
-                            "patient/Medication.read",
-                            "patient/MedicationRequest.read",
-                            "patient/Observation.read",
-                            "patient/Organization.read",
-                            "patient/Patient.read",
-                            "patient/Practitioner.read",
-                            "patient/PractitionerRole.read",
-                            "patient/Procedure.read",
-                            "patient/Provenance.read",
-                            "patient/RelatedPerson.read"
-                        ],
-                        "capabilities": [
-                            "sso-openid-connect",
-                            "launch-standalone",
-                            "client-public",
-                            "client-confidential-symmetric",
-                            "permission-offline",
-                            "context-standalone-patient",
-                            "permission-patient"
-                        ]
+                        "enabled": {{ .Values.security.smartEnabled }},
+                        "scopes": {{ toJson .Values.security.smartScopes }},
+                        "capabilities": {{ toJson .Values.security.smartCapabilities }}
                     }
                 }
+                {{- end }}
             },
             "notifications": {
                 "kafka": {

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -257,10 +257,16 @@ spec:
               command:
               - bash
               - -c
+              {{- if .Values.security.smartEnabled }}
+              - curl --fail -k -sS 'https://localhost:9443/fhir-server/api/v4/.well-known/smart-configuration'
+              {{- else if .Values.security.oauthEnabled }}
+              - curl --fail -k -sS 'https://localhost:9443/fhir-server/api/v4/metadata'
+              {{- else }}
               - curl --fail -k -sS -u "fhiruser:${FHIR_USER_PASSWORD}" 'https://localhost:9443/fhir-server/api/v4/$healthcheck'
-            initialDelaySeconds: 40
+              {{- end }}
+            initialDelaySeconds: 20
             periodSeconds: 10
-            timeoutSeconds: 2
+            timeoutSeconds: 3
           livenessProbe:
             exec:
               command:

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -66,6 +66,51 @@ db:
   sslConnection: true
   pluginName:
   securityMechanism:
+security:
+  oauthEnabled: false
+  oauthRegUrl:
+  oauthAuthUrl:
+  oauthTokenUrl:
+  smartEnabled: false
+  # -- OAuth 2.0 scopes to advertise from the server
+  # @default -- openid, profile, fhirUser, launch/patient, offline_access, and a set of patient/<resource>.read scopes for a number of resource types.
+  smartScopes: [
+      "openid", "profile", "fhirUser", "launch/patient", "offline_access",
+      "patient/*.read",
+      "patient/AllergyIntolerance.read",
+      "patient/CarePlan.read",
+      "patient/CareTeam.read",
+      "patient/Condition.read",
+      "patient/Device.read",
+      "patient/DiagnosticReport.read",
+      "patient/DocumentReference.read",
+      "patient/Encounter.read",
+      "patient/ExplanationOfBenefit.read",
+      "patient/Goal.read",
+      "patient/Immunization.read",
+      "patient/Location.read",
+      "patient/Medication.read",
+      "patient/MedicationRequest.read",
+      "patient/Observation.read",
+      "patient/Organization.read",
+      "patient/Patient.read",
+      "patient/Practitioner.read",
+      "patient/PractitionerRole.read",
+      "patient/Procedure.read",
+      "patient/Provenance.read",
+      "patient/RelatedPerson.read"
+  ]
+  # -- SMART capabilities to advertise from the server
+  # @default -- sso-openid-connect, launch-standalone, client-public, client-confidential-symmetric, permission-offline, context-standalone-patient, and permission-patient
+  smartCapabilities: [
+      "sso-openid-connect",
+      "launch-standalone",
+      "client-public",
+      "client-confidential-symmetric",
+      "permission-offline",
+      "context-standalone-patient",
+      "permission-patient"
+  ]
 schemaMigration:
   enabled: true
   image:


### PR DESCRIPTION
What this PR does *not* address is the ability to add the `fhir-smart` interceptor to the server's userlib directory...that one will require some thought.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>