### PR TITLE
fix db.name helper and upgrade to ibm-fhir-server 4.9.2

### DIFF
--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.2.2
-appVersion: 4.9.1
+version: 0.2.3
+appVersion: 4.9.2
 dependencies:
   - name: postgresql
     version: 10.10.1
@@ -23,5 +23,7 @@ annotations:
   artifacthub.io/changes: |
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
+    - kind: fixed
+      description: helper uses incorrect helm value for db name when the postgresql subchart disabled
     - kind: changed
-      description: use app.kubernetes.io/* naming scheme for labels
+      description: upgrade to ibm-fhir-server 4.9.2

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.1](https://img.shields.io/badge/AppVersion-4.9.1-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 
@@ -185,7 +185,7 @@ If the `objectStorage.objectStorageSecret` value is set, this helm chart will on
 | fullnameOverride | string | `nil` | Optional override for the fully qualified name of the created kube resources |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ibmcom/ibm-fhir-server"` |  |
-| image.tag | string | `"4.9.1"` |  |
+| image.tag | string | `"4.9.2"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |

--- a/charts/ibm-fhir-server/templates/_helpers.tpl
+++ b/charts/ibm-fhir-server/templates/_helpers.tpl
@@ -92,7 +92,7 @@ Get the user to connect to the database server
 Get the name of the database
 */}}
 {{- define "fhir.database.name" -}}
-{{- ternary .Values.postgresql.postgresqlDatabase .Values.db.database .Values.postgresql.enabled -}}
+{{- ternary .Values.postgresql.postgresqlDatabase .Values.db.name .Values.postgresql.enabled -}}
 {{- end -}}
 
 {{/*

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -12,7 +12,7 @@ extraLabels: {}
 replicaCount: 1
 image:
   repository: ibmcom/ibm-fhir-server
-  tag: "4.9.1"
+  tag: "4.9.2"
   pullPolicy: Always
 imagePullSecrets: []
 # -- Set to true to restrict the API to a particular set of resource type endpoints
@@ -155,6 +155,7 @@ schemaMigration:
   enabled: true
   image:
     repository: ibmcom/ibm-fhir-schematool
+    # 4.9.2 doesn't exist (yet?) due to an automation issue, but there were no schema updates in the release anyway.
     tag: "4.9.1"
     pullPolicy: Always
     pullSecret: all-icr-io


### PR DESCRIPTION
Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>