### PR TITLE
conditionally add ttlSecondsAfterFinished to the schema job

### DIFF
--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.2.3
+version: 0.2.4
 appVersion: 4.9.2
 dependencies:
   - name: postgresql
@@ -23,7 +23,5 @@ annotations:
   artifacthub.io/changes: |
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
-    - kind: fixed
-      description: helper uses incorrect helm value for db name when the postgresql subchart disabled
     - kind: changed
-      description: upgrade to ibm-fhir-server 4.9.2
+      description: conditionally add ttlSecondsAfterFinished to the schema job

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 

--- a/charts/ibm-fhir-server/templates/schematool.yaml
+++ b/charts/ibm-fhir-server/templates/schematool.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "fhir.labels" . | nindent 4 }}
     app.kubernetes.io/component: schematool
 spec:
+  {{- if semverCompare ">=1.21" .Capabilities.KubeVersion.Version }}
+  ttlSecondsAfterFinished: 100
+  {{- end }}
   template:
     metadata:
       name: "{{ .Release.Name }}-schematool"


### PR DESCRIPTION
Helm leaves the job laying around, requiring users to clean that out before an upgrade can be performed.

ttlSecondsAfterFinished is a beta feature introduced in kubernetes 1.21 and its use is hidden behind a feature flag.

I couldn't find any way in helm to test whether the actual capability is enabled or not, so I'm just including it in all installs on kubernetes >=1.21

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>