### PR TITLE
change memory defaults and support extra jvm and environment variables (#38)

### DIFF
--- a/charts/ibm-fhir-server/Chart.lock
+++ b/charts/ibm-fhir-server/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.10.1
-digest: sha256:59f732eadb0d4ff89af52a3566a700eea51063028dbf592493572b5154386017
-generated: "2021-09-19T19:18:52.6856314+02:00"
+  version: 10.12.0
+digest: sha256:2ffcec5ec01e777cad48b7d12f6de471fb08a6e9296fc4cfc56b37a795c24af8
+generated: "2021-10-04T13:34:04.528007-04:00"

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.2.4
+version: 0.3.0
 appVersion: 4.9.2
 dependencies:
   - name: postgresql
-    version: 10.10.1
+    version: 10.12.0
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 sources:
@@ -24,4 +24,22 @@ annotations:
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
     - kind: changed
-      description: conditionally add ttlSecondsAfterFinished to the schema job
+      description: upgrade to the latest bitnami postgresql chart
+    - kind: changed
+      description: only create the fhir-db-secret when we actually need it
+    - kind: changed
+      description: support templated hostnames in the default fhir-server-config
+    - kind: added
+      description: support for sizing the initial and maximum memory allocation pools
+    - kind: changed
+      description: the default minHeap (-Xms) size is now 1024m (was 4096m)
+    - kind: changed
+      description: the default kubernetes memory request is now 2Gi (was 4Gi)
+    - kind: changed
+      description: the default replicaCount is now 2
+    - kind: added
+      description: support for setting custom JVM options
+    - kind: added
+      description: support for setting custom environement variables
+    - kind: added
+      description: support for setting the Liberty trace specification via helm

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -13,7 +13,7 @@ ConfigMaps and Secrets to support the wide range of configuration options availa
 
 ```sh
 helm repo add alvearie https://alvearie.io/alvearie-helm
-helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret' --render-subchart-notes
+helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret'
 ```
 
 This will install the latest version if the IBM FHIR Server using an included PostgreSQL database for persistence.

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 
@@ -13,7 +13,7 @@ ConfigMaps and Secrets to support the wide range of configuration options availa
 
 ```sh
 helm repo add alvearie https://alvearie.io/alvearie-helm
-helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret'
+helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret' --render-subchart-notes
 ```
 
 This will install the latest version if the IBM FHIR Server using an included PostgreSQL database for persistence.
@@ -175,6 +175,8 @@ If the `objectStorage.objectStorageSecret` value is set, this helm chart will on
 | endpoints[0].searchParameters | list | `[{"code":"*","url":"*"}]` | A mapping from enabled search parameter codes to search parameter definitions |
 | endpoints[0].searchRevIncludes | list | `nil` | Valid _revInclude arguments while searching this resource type; nil means no restrictions |
 | extensionSearchParametersTemplate | string | `"defaultSearchParameters"` | Template containing the extension-search-parameters.json content |
+| extraEnv | string | `""` |  |
+| extraJvmOptions | string | `""` |  |
 | extraLabels | object | `{}` | Extra labels to apply to the created kube resources |
 | fhirAdminPassword | string | `"change-password"` | The fhirAdminPassword. If fhirPasswordSecret is set, the fhirAdminPassword will be set from its contents. |
 | fhirAdminPasswordSecretKey | string | `nil` | For the Secret specified in fhirPasswordSecret, the key of the key/value pair containing the fhirAdminPassword. This value will be ignored if the fhirPasswordSecret value is not set. |
@@ -189,12 +191,13 @@ If the `objectStorage.objectStorageSecret` value is set, this helm chart will on
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.hostname | string | `"fhir.example.com"` | The default cluster hostname, used for both ingress.rules.host and ingress.tls.hosts. If you have more than one, you'll need to set overrides for the rules and tls separately. |
-| ingress.rules[0].host | string | `"{{ .Release.Name }}.{{ $.Values.ingress.hostname }}"` |  |
+| ingress.hostname | string | `"{{ .Release.Name }}.example.com"` | The default cluster hostname, used for both ingress.rules.host and ingress.tls.hosts. If you have more than one, you'll need to set overrides for the rules and tls separately. |
+| ingress.rules[0].host | string | `"{{ tpl $.Values.ingress.hostname $ }}"` |  |
 | ingress.rules[0].paths[0] | string | `"/"` |  |
 | ingress.servicePort | string | `"https"` |  |
-| ingress.tls[0].hosts[0] | string | `"{{ $.Values.ingress.hostname }}"` |  |
 | ingress.tls[0].secretName | string | `""` |  |
+| maxHeap | string | `"4096m"` |  |
+| minHeap | string | `"1024m"` |  |
 | nameOverride | string | `nil` | Optional override for chart name portion of the created kube resources |
 | notifications.kafka.bootstrapServers | string | `nil` |  |
 | notifications.kafka.enabled | bool | `false` |  |
@@ -234,11 +237,11 @@ If the `objectStorage.objectStorageSecret` value is set, this helm chart will on
 | postgresql.image.tag | string | `"13.4.0-debian-10-r37"` | the tag for the postgresql image |
 | postgresql.postgresqlDatabase | string | `"fhir"` | name of the database to create. see: <https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run> |
 | postgresql.postgresqlExtendedConf | object | `{"maxPreparedTransactions":24}` | Extended Runtime Config Parameters (appended to main or default configuration) |
-| replicaCount | int | `1` | The number of replicas for the externally-facing FHIR server pods |
+| replicaCount | int | `2` | The number of replicas for the externally-facing FHIR server pods |
 | resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | resources.limits.memory | string | `"5Gi"` |  |
 | resources.requests.ephemeral-storage | string | `"1Gi"` |  |
-| resources.requests.memory | string | `"4Gi"` |  |
+| resources.requests.memory | string | `"2Gi"` |  |
 | restrictEndpoints | bool | `false` | Set to true to restrict the API to a particular set of resource type endpoints |
 | schemaMigration.enabled | bool | `true` |  |
 | schemaMigration.image.pullPolicy | string | `"Always"` |  |
@@ -253,6 +256,7 @@ If the `objectStorage.objectStorageSecret` value is set, this helm chart will on
 | security.smartEnabled | bool | `false` |  |
 | security.smartScopes | list | openid, profile, fhirUser, launch/patient, offline_access, and a set of patient/<resource>.read scopes for a number of resource types. | OAuth 2.0 scopes to advertise from the server |
 | serverRegistryResourceProviderEnabled | bool | `false` | Indicates whether the server registry resource provider should be used by the FHIR registry component to access definitional resources through the persistence layer |
+| traceSpec | string | `"*=info"` | The trace specification to use for selectively tracing components of the IBM FHIR Server. The log detail level specification is in the following format: `component1=level1:component2=level2` See https://openliberty.io/docs/latest/log-trace-configuration.html for more information. |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)

--- a/charts/ibm-fhir-server/README.md.gotmpl
+++ b/charts/ibm-fhir-server/README.md.gotmpl
@@ -13,7 +13,7 @@ ConfigMaps and Secrets to support the wide range of configuration options availa
 
 ```sh
 helm repo add alvearie https://alvearie.io/alvearie-helm
-helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret'
+helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret' --render-subchart-notes
 ```
 
 This will install the latest version if the IBM FHIR Server using an included PostgreSQL database for persistence.

--- a/charts/ibm-fhir-server/README.md.gotmpl
+++ b/charts/ibm-fhir-server/README.md.gotmpl
@@ -13,7 +13,7 @@ ConfigMaps and Secrets to support the wide range of configuration options availa
 
 ```sh
 helm repo add alvearie https://alvearie.io/alvearie-helm
-helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret' --render-subchart-notes
+helm upgrade --install --render-subchart-notes ibm-fhir-server alvearie/ibm-fhir-server --values values.yaml --set 'ingress.hostname=example.com' --set 'ingress.tls[0].secretName=cluster-tls-secret'
 ```
 
 This will install the latest version if the IBM FHIR Server using an included PostgreSQL database for persistence.

--- a/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
+++ b/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
@@ -9,7 +9,7 @@ The default fhir-server-config.json.
             "core": {
                 "serverRegistryResourceProviderEnabled": {{ .Values.serverRegistryResourceProviderEnabled }},
                 {{- if .Values.ingress.enabled }}
-                "externalBaseUrl": "https://{{ .Values.ingress.hostname }}/fhir-server/api/v4",
+                "externalBaseUrl": "https://{{ tpl .Values.ingress.hostname $ }}/fhir-server/api/v4",
                 {{- end}}
                 "disabledOperations": "",
                 "defaultPrettyPrint": true

--- a/charts/ibm-fhir-server/templates/configMap.yaml
+++ b/charts/ibm-fhir-server/templates/configMap.yaml
@@ -11,3 +11,13 @@ data:
     {{- include .Values.extensionSearchParametersTemplate . }}
   fhir-server-config.json: >
     {{- include .Values.fhirServerConfigTemplate . }}
+  jvm.options: |
+    # Initial heap size
+    -Xms{{ .Values.minHeap }}
+
+    # Maximum heap size
+    -Xmx{{ .Values.maxHeap }}
+
+    {{- with .Values.extraJvmOptions }}
+    {{ tpl . $ | nindent 4 }}
+    {{- end }}

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "fhir.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
   annotations:
-    checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+    rollme: {{ randAlphaNum 5 | quote }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "fhir.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -70,7 +72,14 @@ spec:
               mountPath: /opt/ol/wlp/usr/servers/defaultServer/configDropins/overrides/datasources.xml
               subPath: datasources.xml
             - name: fhir-server-config
-              mountPath: /opt/ol/wlp/usr/servers/defaultServer/config/default
+              mountPath: /opt/ol/wlp/usr/servers/defaultServer/config/default/fhir-server-config.json
+              subPath: fhir-server-config.json
+            - name: fhir-server-config
+              mountPath: /opt/ol/wlp/usr/servers/defaultServer/config/default/extension-search-parameters.json
+              subPath: extension-search-parameters.json
+            - name: fhir-server-config
+              mountPath: /opt/ol/wlp/usr/servers/defaultServer/jvm.options
+              subPath: jvm.options
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -79,7 +88,7 @@ spec:
             - name: SEC_TLS_TRUSTDEFAULTCERTS
               value: "true"
             - name: TRACE_SPEC
-              value: "*=info:com.ibm.fhir.*=info"
+              value: "{{ .Values.traceSpec }}"
             - name: WLP_LOGGING_MESSAGE_FORMAT
               value: json
             - name: WLP_LOGGING_MESSAGE_SOURCE
@@ -94,7 +103,7 @@ spec:
               value: loglevel:level
             {{- if .Values.ingress.enabled }}
             - name: FHIR_HOSTNAME
-              value: "{{ .Values.ingress.hostname }}"
+              value: "{{ tpl .Values.ingress.hostname $ }}"
             {{- end }}
             - name: FHIR_DB_HOSTNAME
               value: "{{ include "fhir.database.host" $ }}"
@@ -241,6 +250,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "fhir.fullname" . }}-user-secret
                   key: fhir.admin.password
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
             {{- end }}
           readinessProbe:
             exec:

--- a/charts/ibm-fhir-server/templates/fhir-db-secret.yaml
+++ b/charts/ibm-fhir-server/templates/fhir-db-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not (or .Values.db.secret .Values.postgresql.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,4 @@ data:
   {{- if .Values.db.apiKey }}
   apiKey: {{ .Values.db.apiKey | b64enc }}
   {{- end }}
+{{- end }}

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -9,12 +9,16 @@ nameOverride:
 extraLabels: {}
 
 # -- The number of replicas for the externally-facing FHIR server pods
-replicaCount: 1
+replicaCount: 2
 image:
   repository: ibmcom/ibm-fhir-server
   tag: "4.9.2"
   pullPolicy: Always
 imagePullSecrets: []
+# -- The trace specification to use for selectively tracing components of the IBM FHIR Server.
+# The log detail level specification is in the following format: `component1=level1:component2=level2`
+# See https://openliberty.io/docs/latest/log-trace-configuration.html for more information.
+traceSpec: "*=info"
 # -- Set to true to restrict the API to a particular set of resource type endpoints
 restrictEndpoints: false
 # -- Control which interactions are supported for which resource type endpoints
@@ -251,23 +255,26 @@ ingress:
   annotations: {}
   # -- The default cluster hostname, used for both ingress.rules.host and ingress.tls.hosts.
   # If you have more than one, you'll need to set overrides for the rules and tls separately.
-  hostname: fhir.example.com
+  hostname: "{{ .Release.Name }}.example.com"
   rules:
-    - host: "{{ .Release.Name }}.{{ $.Values.ingress.hostname }}"
+    - host: "{{ tpl $.Values.ingress.hostname $ }}"
       paths:
         - "/"
   servicePort: https
   tls:
     - secretName: ""
-      hosts:
-        - "{{ $.Values.ingress.hostname }}"
 resources:
   requests:
-    memory: "4Gi"
+    memory: "2Gi"
     ephemeral-storage: "1Gi"
   limits:
     memory: "5Gi"
     ephemeral-storage: "1Gi"
+
+minHeap: "1024m"
+maxHeap: "4096m"
+extraJvmOptions: ""
+extraEnv: ""
 
 # -- Template containing the fhir-server-config.json content
 fhirServerConfigTemplate: "defaultFhirServerConfig"


### PR DESCRIPTION
    - kind: changed
      description: upgrade to the latest bitnami postgresql chart
    - kind: changed
      description: only create the fhir-db-secret when we actually need it
    - kind: changed
      description: support templated hostnames in the default fhir-server-config
    - kind: added
      description: support for sizing the initial and maximum memory allocation pools
    - kind: changed
      description: the default minHeap (-Xms) size is now 1024m (was 4096m)
    - kind: changed
      description: the default kubernetes memory request is now 2Gi (was 4Gi)
    - kind: changed
      description: the default replicaCount is now 2
    - kind: added
      description: support for setting custom JVM options
    - kind: added
      description: support for setting custom environement variables
    - kind: added
      description: support for setting the Liberty trace specification via helm

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>