### PR TITLE
upgrade ibm-fhir-server and postgres dependency and use configDropin/override for jvm.options

### DIFF
--- a/charts/ibm-fhir-server/Chart.lock
+++ b/charts/ibm-fhir-server/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.12.3
+  version: 10.13.8
 - name: keycloak
   repository: https://codecentric.github.io/helm-charts
   version: 15.1.0
-digest: sha256:f9242c88afef852d886c0c03ed985abe8bbca1aafe52f30bc7ff01fadac8675c
-generated: "2021-10-13T09:59:45.966764-04:00"
+digest: sha256:dd6c0256b3884c1359242ffe44d7f9f2f33d998fcaadb992ca086c52195c291a
+generated: "2021-11-22T09:59:31.513402-05:00"

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
 version: 0.5.1
-appVersion: 4.10.0
+appVersion: 4.10.1
 dependencies:
   - name: postgresql
     version: 10.13.8
@@ -30,7 +30,7 @@ annotations:
     - kind: changed
       description: move jvm.options to configDropins to avoid overwriting
     - kind: changed
-      description: upgrade to ibm-fhir-server 4.10.0
+      description: upgrade to ibm-fhir-server 4.10.1
     - kind: changed
       description: reduce the default initial heap size and memory request
     - kind: changed

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.5.0
+version: 0.5.1
 appVersion: 4.9.2
 dependencies:
   - name: postgresql
@@ -27,5 +27,5 @@ annotations:
   artifacthub.io/changes: |
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
-    - kind: added
-      description: support for custom pathType and custom http port
+    - kind: changed
+      description: move jvm.options to configDropins to avoid overwriting

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
 version: 0.5.1
-appVersion: 4.9.2
+appVersion: 4.10.0
 dependencies:
   - name: postgresql
-    version: 10.12.3
+    version: 10.13.8
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: keycloak
@@ -29,3 +29,7 @@ annotations:
     # added, changed, deprecated, removed, fixed, and security.
     - kind: changed
       description: move jvm.options to configDropins to avoid overwriting
+    - kind: changed
+      description: upgrade to ibm-fhir-server 4.10.0
+    - kind: changed
+      description: upgrade postgresql image to 13.5 and subchart to 10.13.8

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -35,3 +35,5 @@ annotations:
       description: reduce the default initial heap size and memory request
     - kind: changed
       description: upgrade postgresql image to 13.5 and subchart to 10.13.8
+    - kind: added
+      description: helm values for advanced scheduling (e.g. custom affinity rules)

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -32,4 +32,6 @@ annotations:
     - kind: changed
       description: upgrade to ibm-fhir-server 4.10.0
     - kind: changed
+      description: reduce the default initial heap size and memory request
+    - kind: changed
       description: upgrade postgresql image to 13.5 and subchart to 10.13.8

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.0](https://img.shields.io/badge/AppVersion-4.10.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.1](https://img.shields.io/badge/AppVersion-4.10.1-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -247,9 +247,9 @@ If a truststore Secret is specified, the default truststore file will be replace
 | fhirUserPassword | string | `"change-password"` | The fhirUserPassword. If fhirPasswordSecret is set, the fhirUserPassword will be set from its contents. |
 | fhirUserPasswordSecretKey | string | `nil` | For the Secret specified in fhirPasswordSecret, the key of the key/value pair containing the fhirUserPassword. This value will be ignored if the fhirPasswordSecret value is not set. |
 | fullnameOverride | string | `nil` | Optional override for the fully qualified name of the created kube resources |
-| image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ibmcom/ibm-fhir-server"` |  |
-| image.tag | string | `nil` |  |
+| image.pullPolicy | string | `"Always"` | When to pull the image |
+| image.repository | string | `"ibmcom/ibm-fhir-server"` | The repository to pull the IBM FHIR Server image from |
+| image.tag | string | this chart's appVersion | IBM FHIR Server container image tag |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
@@ -329,11 +329,11 @@ If a truststore Secret is specified, the default truststore file will be replace
 | resources.requests.ephemeral-storage | string | `"1Gi"` |  |
 | resources.requests.memory | string | `"1Gi"` |  |
 | restrictEndpoints | bool | `false` | Set to true to restrict the API to a particular set of resource type endpoints |
-| schemaMigration.enabled | bool | `true` |  |
-| schemaMigration.image.pullPolicy | string | `"Always"` |  |
+| schemaMigration.enabled | bool | `true` | Whether to execute a schema creation/migration job as part of the deploy |
+| schemaMigration.image.pullPolicy | string | `"Always"` | When to pull the image |
 | schemaMigration.image.pullSecret | string | `"all-icr-io"` |  |
-| schemaMigration.image.repository | string | `"ibmcom/ibm-fhir-schematool"` |  |
-| schemaMigration.image.tag | string | `nil` |  |
+| schemaMigration.image.repository | string | `"ibmcom/ibm-fhir-schematool"` | The repository to pull the IBM FHIR Schema Tool image from |
+| schemaMigration.image.tag | string | this chart's appVersion | IBM FHIR Schema Tool container image tag |
 | schemaMigration.resources | object | `{}` | container resources for the schema migration job |
 | security.jwtValidation.audience | string | `"https://{{ tpl $.Values.ingress.hostname $ }}/fhir-server/api/v4"` |  |
 | security.jwtValidation.enabled | bool | `false` |  |

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.0](https://img.shields.io/badge/AppVersion-4.10.0-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 
@@ -190,6 +190,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | string | Required node anti-affinity and preferred zone anti-affinity | Pod affinity |
 | audit.enabled | bool | `false` |  |
 | audit.geoCity | string | `nil` | The city where the server is running |
 | audit.geoCountry | string | `nil` | The country where the server is running |
@@ -248,7 +249,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | fullnameOverride | string | `nil` | Optional override for the fully qualified name of the created kube resources |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ibmcom/ibm-fhir-server"` |  |
-| image.tag | string | `"4.9.2"` |  |
+| image.tag | string | `nil` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
@@ -283,6 +284,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | maxHeap | string | `"4096m"` |  |
 | minHeap | string | `"1024m"` |  |
 | nameOverride | string | `nil` | Optional override for chart name portion of the created kube resources |
+| nodeSelector | object | `{}` | Node labels for Pod assignment |
 | notifications.kafka.bootstrapServers | string | `nil` |  |
 | notifications.kafka.enabled | bool | `false` |  |
 | notifications.kafka.saslJaasConfig | string | `nil` |  |
@@ -318,7 +320,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | postgresql.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | postgresql.enabled | bool | `true` | enable an included PostgreSQL DB. if set to `false`, the connection settings under the `db` key are used |
 | postgresql.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL passwords. The secret must contain the keys `postgresql-password` (the password for `postgresqlUsername` when it is different from `postgres`), `postgresql-postgres-password` (which will override `postgresqlPassword`), `postgresql-replication-password` (which will override `replication.password`), and `postgresql-ldap-password` (used to authenticate on LDAP). The value is evaluated as a template. |
-| postgresql.image.tag | string | `"13.4.0"` | the tag for the postgresql image |
+| postgresql.image.tag | string | `"13.5.0"` | the tag for the postgresql image |
 | postgresql.postgresqlDatabase | string | `"fhir"` | name of the database to create. see: <https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run> |
 | postgresql.postgresqlExtendedConf | object | `{"maxPreparedTransactions":24}` | Extended Runtime Config Parameters (appended to main or default configuration) |
 | replicaCount | int | `2` | The number of replicas for the externally-facing FHIR server pods |
@@ -331,7 +333,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | schemaMigration.image.pullPolicy | string | `"Always"` |  |
 | schemaMigration.image.pullSecret | string | `"all-icr-io"` |  |
 | schemaMigration.image.repository | string | `"ibmcom/ibm-fhir-schematool"` |  |
-| schemaMigration.image.tag | string | `"4.9.2"` |  |
+| schemaMigration.image.tag | string | `nil` |  |
 | schemaMigration.resources | object | `{}` | container resources for the schema migration job |
 | security.jwtValidation.audience | string | `"https://{{ tpl $.Values.ingress.hostname $ }}/fhir-server/api/v4"` |  |
 | security.jwtValidation.enabled | bool | `false` |  |
@@ -353,6 +355,8 @@ If a truststore Secret is specified, the default truststore file will be replace
 | security.oauth.tokenUrl | string | `"https://{{ tpl $.Values.ingress.hostname $ }}/auth/realms/test/protocol/openid-connect/token"` |  |
 | securityContext | object | `{}` | pod security context for the server |
 | serverRegistryResourceProviderEnabled | bool | `false` | Indicates whether the server registry resource provider should be used by the FHIR registry component to access definitional resources through the persistence layer |
+| tolerations | list | `[]` | Node taints to tolerate |
+| topologySpreadConstraints | string | `nil` | Topology spread constraints template |
 | traceSpec | string | `"*=info"` | The trace specification to use for selectively tracing components of the IBM FHIR Server. The log detail level specification is in the following format: `component1=level1:component2=level2` See https://openliberty.io/docs/latest/log-trace-configuration.html for more information. |
 | trustStoreFormat | string | `"PKCS12"` | For the truststore specified in trustStoreSecret, the truststore format (PKCS12 or JKS). This value will be ignored if the trustStoreSecret value is not set. |
 | trustStoreSecret | string | `nil` | Secret containing the FHIR server truststore file and its password. The secret must contain the keys 'fhirTrustStore' (the truststore file contents in the format specified in trustStoreFormat) and 'fhirTrustStorePassword' (the truststore password) |

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -281,8 +281,8 @@ If a truststore Secret is specified, the default truststore file will be replace
 | keycloak.realms.test.clients.infernoBulk.publicClient | bool | `true` |  |
 | keycloak.realms.test.clients.infernoBulk.redirectURIs[0] | string | `"http://localhost:4567/inferno/*"` |  |
 | keycloakConfigTemplate | string | `"defaultKeycloakConfig"` | Template with keycloak-config.json input for the Alvearie keycloak-config project |
-| maxHeap | string | `"4096m"` |  |
-| minHeap | string | `"1024m"` |  |
+| maxHeap | string | `"4096m"` | Max heap size |
+| minHeap | string | `"768m"` | Initial heap size |
 | nameOverride | string | `nil` | Optional override for chart name portion of the created kube resources |
 | nodeSelector | object | `{}` | Node labels for Pod assignment |
 | notifications.kafka.bootstrapServers | string | `nil` |  |
@@ -327,7 +327,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | resources.limits.ephemeral-storage | string | `"1Gi"` |  |
 | resources.limits.memory | string | `"5Gi"` |  |
 | resources.requests.ephemeral-storage | string | `"1Gi"` |  |
-| resources.requests.memory | string | `"2Gi"` |  |
+| resources.requests.memory | string | `"1Gi"` |  |
 | restrictEndpoints | bool | `false` | Set to true to restrict the API to a particular set of resource type endpoints |
 | schemaMigration.enabled | bool | `true` |  |
 | schemaMigration.image.pullPolicy | string | `"Always"` |  |

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -190,7 +190,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | string | Required node anti-affinity and preferred zone anti-affinity | Pod affinity |
+| affinity | string | Preferred zone anti-affinity | Pod affinity |
 | audit.enabled | bool | `false` |  |
 | audit.geoCity | string | `nil` | The city where the server is running |
 | audit.geoCountry | string | `nil` | The country where the server is running |

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.9.2](https://img.shields.io/badge/AppVersion-4.9.2-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -114,7 +114,7 @@ spec:
               mountPath: /opt/ol/wlp/usr/servers/defaultServer/config/default/extension-search-parameters.json
               subPath: extension-search-parameters.json
             - name: fhir-server-config
-              mountPath: /opt/ol/wlp/usr/servers/defaultServer/jvm.options
+              mountPath: /opt/ol/wlp/usr/servers/defaultServer/configDropins/overrides/jvm.options
               subPath: jvm.options
           {{- if .Values.exposeHttpEndpoint }}
             - name: fhir-server-config

--- a/charts/ibm-fhir-server/templates/deployment.yaml
+++ b/charts/ibm-fhir-server/templates/deployment.yaml
@@ -56,6 +56,22 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if eq .Values.db.type "postgresql" }}
       initContainers:
         - name: wait-for-db-to-be-ready
@@ -88,7 +104,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ template "fhir.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: https
@@ -100,7 +116,7 @@ spec:
               protocol: TCP
           {{- end }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:

--- a/charts/ibm-fhir-server/templates/schematool.yaml
+++ b/charts/ibm-fhir-server/templates/schematool.yaml
@@ -53,7 +53,7 @@ spec:
         {{- end }}
       containers:
         - name: fhir-schematool
-          image: {{ .Values.schemaMigration.image.repository }}:{{ .Values.schemaMigration.image.tag }}
+          image: {{ .Values.schemaMigration.image.repository }}:{{ .Values.schemaMigration.image.tag | default .Chart.AppVersion }}
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -11,9 +11,12 @@ extraLabels: {}
 # -- The number of replicas for the externally-facing FHIR server pods
 replicaCount: 2
 image:
+  # -- The repository to pull the IBM FHIR Server image from
   repository: ibmcom/ibm-fhir-server
-  # @default -- {{ .Chart.AppVersion }}
-  tag:
+  # -- IBM FHIR Server container image tag
+  # @default -- this chart's appVersion
+  tag: ""
+  # -- When to pull the image
   pullPolicy: Always
 imagePullSecrets: []
 # -- The trace specification to use for selectively tracing components of the IBM FHIR Server.
@@ -219,11 +222,15 @@ security:
         - "permission-patient"
 
 schemaMigration:
+  # -- Whether to execute a schema creation/migration job as part of the deploy
   enabled: true
   image:
+    # -- The repository to pull the IBM FHIR Schema Tool image from
     repository: ibmcom/ibm-fhir-schematool
-    # @default -- {{ .Chart.AppVersion }}
-    tag:
+    # -- IBM FHIR Schema Tool container image tag
+    # @default -- this chart's appVersion
+    tag: ""
+    # -- When to pull the image
     pullPolicy: Always
     pullSecret: all-icr-io
   # -- container resources for the schema migration job

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -12,7 +12,8 @@ extraLabels: {}
 replicaCount: 2
 image:
   repository: ibmcom/ibm-fhir-server
-  tag: "4.9.2"
+  # @default -- {{ .Chart.AppVersion }}
+  tag:
   pullPolicy: Always
 imagePullSecrets: []
 # -- The trace specification to use for selectively tracing components of the IBM FHIR Server.
@@ -57,7 +58,7 @@ postgresql:
   enabled: true
   image:
     # -- the tag for the postgresql image
-    tag: 13.4.0
+    tag: 13.5.0
   # -- name of the database to create.
   # see: <https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run>
   postgresqlDatabase: "fhir"
@@ -221,7 +222,8 @@ schemaMigration:
   enabled: true
   image:
     repository: ibmcom/ibm-fhir-schematool
-    tag: "4.9.2"
+    # @default -- {{ .Chart.AppVersion }}
+    tag:
     pullPolicy: Always
     pullSecret: all-icr-io
   # -- container resources for the schema migration job
@@ -334,6 +336,28 @@ resources:
   limits:
     memory: "5Gi"
     ephemeral-storage: "1Gi"
+# -- Pod affinity
+# @default -- Required node anti-affinity and preferred zone anti-affinity
+affinity: |
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            {{- include "fhir.matchLabels" . | nindent 10 }}
+        topologyKey: kubernetes.io/hostname
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              {{- include "fhir.matchLabels" . | nindent 12 }}
+          topologyKey: failure-domain.beta.kubernetes.io/zone
+# -- Topology spread constraints template
+topologySpreadConstraints:
+# -- Node labels for Pod assignment
+nodeSelector: {}
+# -- Node taints to tolerate
+tolerations: []
 
 minHeap: "1024m"
 maxHeap: "4096m"

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -337,21 +337,16 @@ resources:
     memory: "5Gi"
     ephemeral-storage: "1Gi"
 # -- Pod affinity
-# @default -- Required node anti-affinity and preferred zone anti-affinity
+# @default -- Preferred zone anti-affinity
 affinity: |
   podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchLabels:
-            {{- include "fhir.matchLabels" . | nindent 10 }}
-        topologyKey: kubernetes.io/hostname
     preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100
         podAffinityTerm:
           labelSelector:
             matchLabels:
               {{- include "fhir.matchLabels" . | nindent 12 }}
-          topologyKey: failure-domain.beta.kubernetes.io/zone
+          topologyKey: topology.kubernetes.io/zone
 # -- Topology spread constraints template
 topologySpreadConstraints:
 # -- Node labels for Pod assignment

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -331,7 +331,7 @@ ingress:
     - secretName: ""
 resources:
   requests:
-    memory: "2Gi"
+    memory: "1Gi"
     ephemeral-storage: "1Gi"
   limits:
     memory: "5Gi"
@@ -359,7 +359,9 @@ nodeSelector: {}
 # -- Node taints to tolerate
 tolerations: []
 
-minHeap: "1024m"
+# -- Initial heap size
+minHeap: "768m"
+# -- Max heap size
 maxHeap: "4096m"
 extraJvmOptions: ""
 extraEnv: ""


### PR DESCRIPTION
so that we avoid overriding the fhir-server's jvm.options file that contains
`-Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault`
which is important for performance.

This also updates the initial heap size default so that it matches the new default in ibm-fhir-server 4.10.0
and, correspondingly, reduces the default kubernetes resource request to 1 GiB.

Finally, I added helm values for https://github.com/Alvearie/alvearie-helm/issues/67 

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>