### PR TITLE
set schemaMigration imagePullPolicy and update chart dependencies

### DIFF
--- a/charts/ibm-fhir-server/Chart.lock
+++ b/charts/ibm-fhir-server/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.13.14
+  version: 10.13.15
 - name: keycloak
   repository: https://codecentric.github.io/helm-charts
-  version: 16.0.4
-digest: sha256:763042151638a4088893779775bae372d39f6e35f9f44188300847dc3b962ac1
-generated: "2021-12-14T16:00:04.240664-05:00"
+  version: 16.0.5
+digest: sha256:a239f6ff2b5a314d431a14d2cc79fd9cd7d2a7abf5f87cd0b468c0ccb543a73d
+generated: "2022-01-10T15:07:09.876606-05:00"

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.6.0
+version: 0.6.1
 appVersion: 4.10.2
 dependencies:
   - name: postgresql
-    version: 10.13.14
+    version: 10.13.15
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: keycloak
-    version: 16.0.4
+    version: 16.0.5
     repository: https://codecentric.github.io/helm-charts
     condition: keycloak.enabled
 sources:
@@ -26,20 +26,6 @@ annotations:
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
     - kind: changed
-      description: align endpoints config with fhir-server-config.json's fhirServer/resources section
-    - kind: added
-      description: transactionTimeout helm value for setting FHIR_TRANSACTION_MANAGER_TIMEOUT
-    - kind: removed
-      description: the default value for minHeap; instead we will defer to the IBM FHIR Server default
-    - kind: removed
-      description: the default value for maxHeap; instead we will defer to the JVM default
-    - kind: changed
-      description: update the optional postgresql image's default to version 14.1.0
-    - kind: changed
-      description: changed default pullPolicy values to IfNotPresent
-    - kind: changed
-      description: updated to smart-keycloak and keycloak-config 0.4.1 (now from quay.io)
-    - kind: changed
-      description: updated keycloak-config init container image to ubi 8.5
-    - kind: added
-      description: values for enabling/disabling keycloak-config and controlling which image is used
+      description: update chart dependency versions
+    - kind: fixed
+      description: added schemaMigration image pullPolicy to schematool job

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.2](https://img.shields.io/badge/AppVersion-4.10.2-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.2](https://img.shields.io/badge/AppVersion-4.10.2-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 

--- a/charts/ibm-fhir-server/templates/schematool.yaml
+++ b/charts/ibm-fhir-server/templates/schematool.yaml
@@ -54,6 +54,7 @@ spec:
       containers:
         - name: fhir-schematool
           image: {{ .Values.schemaMigration.image.repository }}:{{ .Values.schemaMigration.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.schemaMigration.image.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false


### PR DESCRIPTION
I had the schemaMigration imagePullPolicy in the values.yaml file but apparently it never made its way into the schematool job...this fixes that

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>