### PR TITLE
update to ibm-fhir-server 4.11.1 and smart-keycloak 0.5.1

### DIFF
--- a/charts/ibm-fhir-server/Chart.lock
+++ b/charts/ibm-fhir-server/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 10.13.15
 - name: keycloak
   repository: https://codecentric.github.io/helm-charts
-  version: 17.0.3
-digest: sha256:3abe6484696dbd87a27ab7d96870c291ced754bc8afffa255f68a800d528394c
-generated: "2022-03-28T09:33:35.159625-04:00"
+  version: 18.1.1
+digest: sha256:65c21dfb08018acdbe1c1c910c535ba7b6c33f1eaec33b8245a37f9975007b4b
+generated: "2022-05-02T15:47:23.728536-04:00"

--- a/charts/ibm-fhir-server/Chart.yaml
+++ b/charts/ibm-fhir-server/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
 description: Helm chart for the IBM FHIR Server
 name: ibm-fhir-server
-version: 0.6.4
-appVersion: 4.10.2
+version: 0.7.0
+appVersion: 4.11.1
 dependencies:
   - name: postgresql
     version: 10.13.15
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: keycloak
-    version: 17.0.3
+    version: 18.1.1
     repository: https://codecentric.github.io/helm-charts
     condition: keycloak.enabled
 sources:
@@ -26,8 +26,8 @@ annotations:
     # When using the list of objects option the valid supported kinds are
     # added, changed, deprecated, removed, fixed, and security.
     - kind: changed
-      description: liveness probe timeout from 1s (default) to 3s
+      description: bump default ibm-fhir-server image from 4.10.2 to 4.11.1
     - kind: changed
-      description: bump keycloak subchart from 16.0.5 to 17.0.3
+      description: bump keycloak subchart from 17.0.3 to 18.1.1
     - kind: changed
-      description: bump default bitnami postgresql image from 14.1.0 to 14.2.0
+      description: bump default smart-keycloak and keycloak-config images from 0.4.1 to 0.5.1

--- a/charts/ibm-fhir-server/README.md
+++ b/charts/ibm-fhir-server/README.md
@@ -1,5 +1,5 @@
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.10.2](https://img.shields.io/badge/AppVersion-4.10.2-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.11.1](https://img.shields.io/badge/AppVersion-4.11.1-informational?style=flat-square)
 
 # The IBM FHIR Server Helm Chart
 
@@ -266,7 +266,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | keycloak.config.enabled | bool | `true` |  |
 | keycloak.config.image.pullPolicy | string | `"IfNotPresent"` |  |
 | keycloak.config.image.repository | string | `"quay.io/alvearie/keycloak-config"` |  |
-| keycloak.config.image.tag | string | `"0.4.1"` |  |
+| keycloak.config.image.tag | string | `"0.5.1"` |  |
 | keycloak.config.realms.test.clients.inferno.clientAuthenticatorType | string | `"client-secret"` |  |
 | keycloak.config.realms.test.clients.inferno.consentRequired | bool | `true` |  |
 | keycloak.config.realms.test.clients.inferno.defaultScopes[0] | string | `"launch/patient"` |  |
@@ -290,7 +290,7 @@ If a truststore Secret is specified, the default truststore file will be replace
 | keycloak.extraVolumes | string | a single volume named keycloak-admin with contents from the keycloak-admin-secret | Extra volumes for the Keycloak StatefulSets |
 | keycloak.image.pullPolicy | string | `"IfNotPresent"` |  |
 | keycloak.image.repository | string | `"quay.io/alvearie/smart-keycloak"` |  |
-| keycloak.image.tag | string | `"0.4.1"` |  |
+| keycloak.image.tag | string | `"0.5.1"` |  |
 | keycloak.postgresql.nameOverride | string | `"keycloak-postgres"` |  |
 | keycloakConfigTemplate | string | `"defaultKeycloakConfig"` | Template with keycloak-config.json input for the Alvearie keycloak-config project |
 | maxHeap | string | `""` | The value passed to the JVM via -Xmx to set the max heap size. |

--- a/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
+++ b/charts/ibm-fhir-server/templates/_fhirServerConfigJson.tpl
@@ -14,9 +14,6 @@ The default fhir-server-config.json.
                 "disabledOperations": "",
                 "defaultPrettyPrint": true
             },
-            "search": {
-                "useStoredCompartmentParam": true
-            },
             "resources": {
                 "open": {{ not .Values.restrictEndpoints }}
                 {{- range $endpoint, $conf := .Values.endpoints }},

--- a/charts/ibm-fhir-server/values.yaml
+++ b/charts/ibm-fhir-server/values.yaml
@@ -115,7 +115,7 @@ keycloak:
   enabled: false
   image:
     repository: quay.io/alvearie/smart-keycloak
-    tag: 0.4.1
+    tag: 0.5.1
     pullPolicy: IfNotPresent
   # -- An initial keycloak admin username for creating the initial Keycloak admin user
   adminUsername: admin
@@ -147,7 +147,7 @@ keycloak:
     enabled: true
     image:
       repository: quay.io/alvearie/keycloak-config
-      tag: 0.4.1
+      tag: 0.5.1
       pullPolicy: IfNotPresent
     ttlSecondsAfterFinished: 100
     realms:


### PR DESCRIPTION
and bump the keycloak subchart version from 17.0.3 to 18.1.1

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>